### PR TITLE
Change `basestring` to `str` for Python 3

### DIFF
--- a/RoboREPL.roboFontExt/lib/roboREPL.py
+++ b/RoboREPL.roboFontExt/lib/roboREPL.py
@@ -116,7 +116,7 @@ def settingsBoolValidator(value):
     return isinstance(value, bool)
 
 def settingsStringValidator(value):
-    return isinstance(value, basestring)
+    return isinstance(value, str)
 
 def settingsNumberValidator(value):
     return isinstance(value, (int, float))


### PR DESCRIPTION
`basestring`, which was removed in Python 3, causes errors when changing settings with strings.
eg. settings.fontName = "FiraCode-Regular"